### PR TITLE
Use activity chooser for share intents

### DIFF
--- a/app/src/main/java/com/malmstein/yahnac/stories/NewsActivity.java
+++ b/app/src/main/java/com/malmstein/yahnac/stories/NewsActivity.java
@@ -23,6 +23,7 @@ public class NewsActivity extends HNewsActivity implements StoryListener {
 
     public static final int INITIAL_PAGE = 1;
     private static final int OFFSCREEN_PAGE_LIMIT = 1;
+    private static final CharSequence SHARE_DIALOG_DEFAULT_TITLE = null;
     private AppBarContainer appBarContainer;
     private ViewPager headersPager;
     private SlidingTabLayout slidingTabs;
@@ -85,7 +86,8 @@ public class NewsActivity extends HNewsActivity implements StoryListener {
 
     @Override
     public void onShareClicked(Intent shareIntent) {
-        startActivity(shareIntent);
+        Intent chooserIntent = Intent.createChooser(shareIntent, SHARE_DIALOG_DEFAULT_TITLE);
+        startActivity(chooserIntent);
     }
 
     @Override


### PR DESCRIPTION
For sharing we don't want the default behavior where users are able to select a preferred app that will be automatically used for future intent launches.

Before:
![yahnac_share_before](https://cloud.githubusercontent.com/assets/218061/6911077/03cf7d04-d75c-11e4-92a2-954a66c8782b.png)

After:
![yahnac_share_after](https://cloud.githubusercontent.com/assets/218061/6911079/08a61220-d75c-11e4-9f86-512ce2ffa1d3.png)
