### PR TITLE
Use activity chooser for share intents

### DIFF
--- a/app/src/main/java/com/malmstein/yahnac/stories/NewsActivity.java
+++ b/app/src/main/java/com/malmstein/yahnac/stories/NewsActivity.java
@@ -23,6 +23,7 @@ public class NewsActivity extends HNewsActivity implements StoryListener{
 
     public static final int INITIAL_PAGE = 1;
     private static final int OFFSCREEN_PAGE_LIMIT = 1;
+    private static final CharSequence SHARE_DIALOG_DEFAULT_TITLE = null;
     private ViewPager headersPager;
     private SlidingTabLayout slidingTabs;
     private StoriesPagerAdapter headersAdapter;
@@ -87,7 +88,8 @@ public class NewsActivity extends HNewsActivity implements StoryListener{
 
     @Override
     public void onShareClicked(Intent shareIntent) {
-        startActivity(shareIntent);
+        Intent chooserIntent = Intent.createChooser(shareIntent, SHARE_DIALOG_DEFAULT_TITLE);
+        startActivity(chooserIntent);
     }
 
     @Override


### PR DESCRIPTION
For sharing we don't want the default behavior where users are able to select a preferred app that will be automatically used for future intent launches.

Before:
![yahnac_share_before](https://cloud.githubusercontent.com/assets/218061/6911135/ccf3abba-d75c-11e4-92b4-a2599ef71fe7.png)

After:
![yahnac_share_after](https://cloud.githubusercontent.com/assets/218061/6911139/d1435468-d75c-11e4-933c-45e691c967b7.png)
