### PR TITLE
Update Travis-CI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
 language: android
+
 android:
   components:
-    - platform-tools
-    - tools
-
-    # The BuildTools version used by your project
-    - build-tools-22.0.1
-
-    # The SDK version used to compile your project
-    - android-22
-
-    # Additional components
-    # - extra-google-google_play_services
-    # - extra-google-m2repository
+    - build-tools-23.0.1
+    - android-23
+    - extra-android-support
+    - extra-google-m2repository
     - extra-android-m2repository
 
-before_script:
-    - chmod +x gradlew
-#Build, and run tests
-script: "./gradlew build"
-sudo: false
+script:
+  - ./gradlew build -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 
 android:
   components:
-    - build-tools-23.0.2
+    - build-tools-23.0.1
     - android-23
     - extra-android-support
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ android:
     - extra-android-m2repository
 
 script:
-  - ./gradlew build -i
+  - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ android:
     - extra-android-m2repository
 
 script:
-  - ./gradlew build
+  - ./gradlew build -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 
 android:
   components:
-    - build-tools-23.0.1
+    - build-tools-23.0.2
     - android-23
     - extra-android-support
     - extra-google-m2repository

--- a/app/src/main/java/com/malmstein/yahnac/HNewsActivity.java
+++ b/app/src/main/java/com/malmstein/yahnac/HNewsActivity.java
@@ -32,18 +32,6 @@ public class HNewsActivity extends AppCompatActivity {
         navigator = new Navigator(this);
     }
 
-    @Override
-    protected void onStart() {
-        super.onStart();
-        navigator.onStart();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        navigator.onStop();
-    }
-
     private void initNetworkChecker() {
         networkChecker = new NetworkChecker(this);
     }

--- a/app/src/main/java/com/malmstein/yahnac/analytics/UsageAnalytics.java
+++ b/app/src/main/java/com/malmstein/yahnac/analytics/UsageAnalytics.java
@@ -19,7 +19,6 @@ public class UsageAnalytics {
 
     public void initTracker(Context context) {
         GoogleAnalytics analytics = GoogleAnalytics.getInstance(context);
-        analyticsTracker = analytics.newTracker(R.xml.global_tracker);
     }
 
     public void trackPage(String page) {

--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,6 @@ allprojects {
             url 'http://download.crashlytics.com/maven'
         }
         maven {
-            url "http://ci.novoda.com/maven/releases"
-        }
-        maven {
             url "http://dl.bintray.com/novoda/maven"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     configuration = [
             package          : "com.malmstein.yahnac",
-            buildToolsVersion: "23.0.2",
+            buildToolsVersion: "23.0.1",
             minSdk           : 16,
             targetSdk        : 23,
             compileSdk       : 23,

--- a/build.gradle
+++ b/build.gradle
@@ -12,16 +12,9 @@ ext {
 
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
         maven {
             url 'http://download.crashlytics.com/maven'
-        }
-        maven {
-            url "http://ci.novoda.com/maven/releases"
-        }
-        maven {
-            url "http://dl.bintray.com/novoda/maven"
         }
     }
 


### PR DESCRIPTION
Merry Christmas @malmstein!!!

This PR contains the fix for #31. The fix is based on:

* Update Travis-CI configuration. Travis-CI does not support Android Build tools 23.0.2 so I've changed the version used to the one supported: 23.0.1.
* Update the root build.gradle file to remove some not needed dependencies.
* Remove some code was not compiling. Please review this carefully, I don't why was not compiling.

The problem you had with your Travis-CI configuration it's not related to the application build. The problem is in your artefacts repository hosted at http://ci.novoda.com/maven/releases which is completely down or not accesible from the Travis-CI environment. Http requests to this repository were getting timeouts continuously and that's why all your Travis-CI builds were failing. 

![MerryChristmas](https://media0.giphy.com/media/2IfqRSy8jfOVO/200.gif)