### PR TITLE
Added ripple to toolbar icons in articles and comments

### DIFF
--- a/app/src/main/res/layout/activity_comments.xml
+++ b/app/src/main/res/layout/activity_comments.xml
@@ -9,7 +9,7 @@
     android:id="@+id/appbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+    android:theme="@style/Theme.HNews.Collapsing">
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_story.xml
+++ b/app/src/main/res/layout/activity_story.xml
@@ -8,7 +8,7 @@
     android:id="@+id/appbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+    android:theme="@style/Theme.HNews.Collapsing">
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -21,6 +21,11 @@
     <item name="colorAccent">@color/white</item>
   </style>
 
+    <style name="Theme.HNews.Collapsing" parent="ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="android:actionBarItemBackground">?attr/selectableItemBackground</item>
+        <item name="actionBarItemBackground">?attr/selectableItemBackground</item>
+    </style>
+
   <style name="Theme.HNews.News">
     <item name="dialogOrientation">vertical</item>
     <item name="dialogTitleWidth">match_parent</item>


### PR DESCRIPTION
The problem: addressing issue https://github.com/malmstein/yahnac/issues/24

The icons now have ripple effect. Applied the solution desribed here: https://code.google.com/p/android/issues/detail?id=176431