### PR TITLE
CommandParser: Adjust parseText() to match new website layout.

### DIFF
--- a/app/src/main/java/com/malmstein/yahnac/comments/parser/CommentsParser.java
+++ b/app/src/main/java/com/malmstein/yahnac/comments/parser/CommentsParser.java
@@ -60,7 +60,7 @@ public class CommentsParser {
     }
 
     public String parseText(Element topRowElement) {
-        Element commentSpan = topRowElement.select("span.comment > span").first();
+        Element commentSpan = topRowElement.select("div.comment > span").first();
         if (commentSpan == null) {
             return "";
         }


### PR DESCRIPTION
This patch fixes issue #46.

A "span.comment" parseText() selects does not exist on the website anymore
and therefore the app does not display any comment text. With this patch
the comment is now grabbed from the first span inside a "div.comment".