### PR TITLE
Remove optional trailing newline characters from styled comments.

### DIFF
--- a/app/src/main/java/com/malmstein/yahnac/comments/CommentsAdapter.java
+++ b/app/src/main/java/com/malmstein/yahnac/comments/CommentsAdapter.java
@@ -2,7 +2,6 @@ package com.malmstein.yahnac.comments;
 
 import android.database.Cursor;
 import android.support.v7.widget.RecyclerView;
-import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -104,7 +103,7 @@ public class CommentsAdapter extends CursorRecyclerAdapter<RecyclerView.ViewHold
         }
 
         public void bind(final Comment comment, LoginSharedPreferences loginSharedPreferences, final Listener listener, String type) {
-            text.setText(Html.fromHtml(comment.getText()));
+            text.setText(comment.getStyledText());
             text.setMovementMethod(LinkMovementMethod.getInstance());
             if (comment.isHeader() || type.equals("ask")) {
                 comment_header.setVisibility(View.GONE);
@@ -155,7 +154,7 @@ public class CommentsAdapter extends CursorRecyclerAdapter<RecyclerView.ViewHold
         }
 
         public void bind(final Comment comment, LoginSharedPreferences loginSharedPreferences, final Listener listener) {
-            text.setText(Html.fromHtml(comment.getText()));
+            text.setText(comment.getStyledText());
             text.setMovementMethod(LinkMovementMethod.getInstance());
             author.setText(comment.getBy());
             when.setText(comment.getTimeText());

--- a/app/src/main/java/com/malmstein/yahnac/model/Comment.java
+++ b/app/src/main/java/com/malmstein/yahnac/model/Comment.java
@@ -1,6 +1,7 @@
 package com.malmstein.yahnac.model;
 
 import android.database.Cursor;
+import android.text.Html;
 
 import com.malmstein.yahnac.data.HNewsContract;
 
@@ -41,6 +42,26 @@ public class Comment {
 
     public String getText() {
         return text;
+    }
+
+    /**
+     * Returns displayable styled comment text.
+     */
+    public CharSequence getStyledText() {
+        // First transform the HTML String into a styled CharSequence.
+        final CharSequence styledText = Html.fromHtml(getText());
+
+        // Now remove optional trailing newline characters.
+        int end = styledText.length();
+        while (end >= 0 && styledText.charAt(end - 1) == '\n') {
+            end--;
+        }
+
+        if (end != styledText.length()) {
+            return styledText.subSequence(0, end);
+        } else {
+            return styledText;
+        }
     }
 
     public int getLevel() {


### PR DESCRIPTION
This patch fixes issue #48.

Html.fromHtml() adds newline characters to the end of the styled text if the comment consists of multiple paragraphs (`<p>..</p> <p>..</p>`).